### PR TITLE
Fix Google Workspace log collection gaps

### DIFF
--- a/GWS/gws-log-collection/gws-get-logs.py
+++ b/GWS/gws-log-collection/gws-get-logs.py
@@ -5,6 +5,8 @@ import requests
 import os
 import argparse
 import logging
+import shutil
+import tempfile
 from googleapiclient.discovery import build
 from google.oauth2 import service_account
 from dateutil import parser as dateparser, tz
@@ -77,6 +79,7 @@ class Google(object):
         """
 
         total_saved, total_found = 0, 0
+        base_from_date = from_date
 
         for app in self.app_list:
 
@@ -84,19 +87,20 @@ class Google(object):
             output_file = f"{self.output_path}/{app}_logs.json"
 
             # Get most recent log entry date (if required)
+            only_after_datetime = base_from_date
             if self.update:
-                from_date = self._check_recent_date(output_file) or from_date
+                only_after_datetime = self._check_recent_date(output_file) or base_from_date
 
             # Collect logs for specified app
             logging.info(f"Collecting logs for {app}...")
-            if from_date:
-                logging.debug(f"Only extracting records after {from_date}")
+            if only_after_datetime:
+                logging.debug(f"Only extracting records after {only_after_datetime}")
 
             saved, found = self._get_activity_logs(
                 app, 
                 output_file=output_file, 
                 overwrite=self.overwrite, 
-                only_after_datetime=from_date
+                only_after_datetime=only_after_datetime
             )
             logging.info(f"Saved {saved} of {found} entries for {app}")
             total_saved += saved
@@ -107,35 +111,81 @@ class Google(object):
     def _get_activity_logs(self, application_name, output_file, overwrite=False, only_after_datetime=None):
         """ Collect activitiy logs from the specified application """
 
-        # Call the Admin SDK Reports API
-        try:
-            results = self.service.activities().list(
-                userKey='all', applicationName=application_name).execute()
-        except TypeError as e:
-            logging.error(f"Error collecting logs for {application_name}: {e}")
-            return False, False
-
-        activities = results.get('items', [])
         output_count = 0
-        if activities:
-            with open(output_file, 'w' if overwrite else 'a') as output:
+        total_count = 0
+        next_page_token = None
+        output_dir = os.path.dirname(os.path.abspath(output_file)) or '.'
+        page_files = []
+        staged_output = None
+        found_activities = False
 
-                # Loop through activities in reverse order (so latest events are at the end)
-                for entry in activities[::-1]:
-                    # TODO: See if we can speed this up to prevent looping through all activities
+        try:
+            while True:
+                request = {
+                    'userKey': 'all',
+                    'applicationName': application_name
+                }
+                if only_after_datetime:
+                    request['startTime'] = only_after_datetime.astimezone(
+                        tz.gettz('UTC')).isoformat().replace('+00:00', 'Z')
+                if next_page_token:
+                    request['pageToken'] = next_page_token
 
-                    # If we're only exporting new records, check the datetime of the record
-                    if only_after_datetime:
-                        entry_datetime = dateparser.parse(entry['id']['time'])
-                        if (entry_datetime <= only_after_datetime):
-                            continue  # Skip this record
+                try:
+                    results = self.service.activities().list(**request).execute()
+                except TypeError as e:
+                    logging.error(f"Error collecting logs for {application_name}: {e}")
+                    return False, False
 
-                    # Output this record
-                    json_formatted_str = json.dumps(entry)
-                    output.write(f"{json_formatted_str}\n")
-                    output_count += 1
+                activities = results.get('items', [])
+                total_count += len(activities)
+                if activities:
+                    found_activities = True
+                    fd, page_file = tempfile.mkstemp(
+                        prefix='gws_page_', suffix='.json', dir=output_dir)
+                    page_files.append(page_file)
+                    with os.fdopen(fd, 'w') as page_output:
+                        # Loop through activities in reverse order (so latest events are at the end)
+                        for entry in activities[::-1]:
+                            # TODO: See if we can speed this up to prevent looping through all activities
 
-        return output_count, len(activities)
+                            # If we're only exporting new records, check the datetime of the record
+                            if only_after_datetime:
+                                entry_datetime = dateparser.parse(entry['id']['time'])
+                                if (entry_datetime <= only_after_datetime):
+                                    continue  # Skip this record
+
+                            # Output this record
+                            json_formatted_str = json.dumps(entry)
+                            page_output.write(f"{json_formatted_str}\n")
+                            output_count += 1
+
+                next_page_token = results.get('nextPageToken')
+                if not next_page_token:
+                    break
+
+            if found_activities:
+                fd, staged_output = tempfile.mkstemp(
+                    prefix='gws_logs_', suffix='.json', dir=output_dir)
+                with os.fdopen(fd, 'w') as staged_file:
+                    for page_file in page_files[::-1]:
+                        with open(page_file, 'r') as page_output:
+                            shutil.copyfileobj(page_output, staged_file)
+
+                if overwrite:
+                    os.replace(staged_output, output_file)
+                    staged_output = None
+                else:
+                    with open(output_file, 'a') as output, open(staged_output, 'r') as staged_file:
+                        shutil.copyfileobj(staged_file, output)
+
+            return output_count, total_count
+        finally:
+            if staged_output and os.path.exists(staged_output):
+                os.remove(staged_output)
+            for page_file in page_files:
+                if os.path.exists(page_file):
+                    os.remove(page_file)
 
 
 if __name__ == '__main__':

--- a/test_gws_get_logs.py
+++ b/test_gws_get_logs.py
@@ -1,0 +1,222 @@
+import importlib.util
+import json
+import logging
+import sys
+import tempfile
+import types
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).parent / "GWS" / "gws-log-collection" / "gws-get-logs.py"
+
+
+def load_module():
+    sys.modules.setdefault("requests", types.SimpleNamespace(get=lambda *args, **kwargs: None))
+    googleapiclient = types.ModuleType("googleapiclient")
+    discovery = types.ModuleType("googleapiclient.discovery")
+    discovery.build = lambda *args, **kwargs: None
+    sys.modules.setdefault("googleapiclient", googleapiclient)
+    sys.modules.setdefault("googleapiclient.discovery", discovery)
+
+    google = types.ModuleType("google")
+    oauth2 = types.ModuleType("google.oauth2")
+    service_account = types.ModuleType("google.oauth2.service_account")
+    service_account.Credentials = types.SimpleNamespace(from_service_account_file=lambda *args, **kwargs: None)
+    sys.modules.setdefault("google", google)
+    sys.modules.setdefault("google.oauth2", oauth2)
+    sys.modules.setdefault("google.oauth2.service_account", service_account)
+
+    dateutil = types.ModuleType("dateutil")
+    parser = types.ModuleType("dateutil.parser")
+    tz = types.ModuleType("dateutil.tz")
+    parser.parse = lambda value: datetime.fromisoformat(value.replace("Z", "+00:00"))
+    tz.gettz = lambda name: timezone.utc if name == "UTC" else None
+    sys.modules.setdefault("dateutil", dateutil)
+    sys.modules.setdefault("dateutil.parser", parser)
+    sys.modules.setdefault("dateutil.tz", tz)
+
+    spec = importlib.util.spec_from_file_location("gws_get_logs", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def activity(timestamp, name):
+    return {"id": {"time": timestamp, "uniqueQualifier": name}}
+
+
+class FakeListCall:
+    def __init__(self, page):
+        self.page = page
+
+    def execute(self):
+        if isinstance(self.page, Exception):
+            raise self.page
+        return self.page
+
+
+class FakeActivities:
+    def __init__(self, pages):
+        self.pages = list(pages)
+        self.calls = []
+
+    def list(self, **kwargs):
+        self.calls.append(kwargs)
+        index = len(self.calls) - 1
+        return FakeListCall(self.pages[index])
+
+
+class FakeService:
+    def __init__(self, pages):
+        self.fake_activities = FakeActivities(pages)
+
+    def activities(self):
+        return self.fake_activities
+
+
+class GoogleWorkspaceLogTests(unittest.TestCase):
+    def test_get_activity_logs_follows_all_result_pages(self):
+        module = load_module()
+        google = module.Google.__new__(module.Google)
+        google.service = FakeService(
+            [
+                {
+                    "items": [activity("2026-01-01T00:01:00Z", "second")],
+                    "nextPageToken": "page-two",
+                },
+                {
+                    "items": [activity("2026-01-01T00:00:00Z", "first")],
+                },
+            ]
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            output_file = Path(tmp) / "login_logs.json"
+            saved, found = google._get_activity_logs("login", str(output_file), overwrite=True)
+            written = [json.loads(line) for line in output_file.read_text().splitlines()]
+
+        self.assertEqual(saved, 2)
+        self.assertEqual(found, 2)
+        self.assertEqual([entry["id"]["uniqueQualifier"] for entry in written], ["first", "second"])
+        self.assertEqual(
+            google.service.fake_activities.calls,
+            [
+                {"userKey": "all", "applicationName": "login"},
+                {"userKey": "all", "applicationName": "login", "pageToken": "page-two"},
+            ],
+        )
+
+    def test_get_activity_logs_writes_pages_in_global_chronological_order(self):
+        module = load_module()
+        google = module.Google.__new__(module.Google)
+        google.service = FakeService(
+            [
+                {
+                    "items": [
+                        activity("2026-01-01T00:03:00Z", "newest"),
+                        activity("2026-01-01T00:02:00Z", "newer"),
+                    ],
+                    "nextPageToken": "older-page",
+                },
+                {
+                    "items": [
+                        activity("2026-01-01T00:01:00Z", "older"),
+                        activity("2026-01-01T00:00:00Z", "oldest"),
+                    ],
+                },
+            ]
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            output_file = Path(tmp) / "login_logs.json"
+            google._get_activity_logs("login", str(output_file), overwrite=True)
+            written = [json.loads(line) for line in output_file.read_text().splitlines()]
+            temp_files = list(Path(tmp).glob("gws_*.json"))
+
+        self.assertEqual(
+            [entry["id"]["uniqueQualifier"] for entry in written],
+            ["oldest", "older", "newer", "newest"],
+        )
+        self.assertEqual(temp_files, [])
+
+    def test_get_activity_logs_does_not_write_partial_page_on_failure(self):
+        module = load_module()
+        google = module.Google.__new__(module.Google)
+        google.service = FakeService(
+            [
+                {
+                    "items": [activity("2026-01-01T00:01:00Z", "newer")],
+                    "nextPageToken": "failing-page",
+                },
+                TypeError("transient API failure"),
+            ]
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            output_file = Path(tmp) / "login_logs.json"
+            with self.assertLogs(level=logging.ERROR):
+                saved, found = google._get_activity_logs("login", str(output_file), overwrite=True)
+
+        self.assertEqual((saved, found), (False, False))
+        self.assertFalse(output_file.exists())
+        self.assertEqual(list(Path(tmp).glob("gws_*.json")), [])
+
+    def test_get_activity_logs_uses_start_time_when_cutoff_is_known(self):
+        module = load_module()
+        google = module.Google.__new__(module.Google)
+        google.service = FakeService(
+            [
+                {
+                    "items": [activity("2026-01-01T00:01:00Z", "newer")],
+                },
+            ]
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            output_file = Path(tmp) / "login_logs.json"
+            google._get_activity_logs(
+                "login",
+                str(output_file),
+                overwrite=True,
+                only_after_datetime=datetime.fromisoformat("2026-01-01T00:00:00+00:00"),
+            )
+
+        self.assertEqual(
+            google.service.fake_activities.calls[0],
+            {
+                "userKey": "all",
+                "applicationName": "login",
+                "startTime": "2026-01-01T00:00:00Z",
+            },
+        )
+
+    def test_update_mode_uses_each_apps_own_recent_timestamp(self):
+        module = load_module()
+        google = module.Google.__new__(module.Google)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            output_path = Path(tmp)
+            (output_path / "login_logs.json").write_text(
+                json.dumps(activity("2026-01-02T00:00:00Z", "login-existing")) + "\n"
+            )
+            google.output_path = str(output_path)
+            google.app_list = ["login", "drive"]
+            google.update = True
+            google.overwrite = False
+            calls = []
+
+            def record_call(application_name, output_file, overwrite=False, only_after_datetime=None):
+                calls.append((application_name, only_after_datetime))
+                return 0, 0
+
+            google._get_activity_logs = record_call
+            google.get_logs(from_date=None)
+
+        self.assertIsNotNone(calls[0][1])
+        self.assertEqual(calls[1], ("drive", None))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Follow Google Admin Reports API `nextPageToken` values so log collection includes every result page.
- Keep update-mode timestamp filters scoped to each application so one app cannot suppress another app's first collection.
- Stage paginated page output before committing it to disk, avoiding partial output files on later-page failures while preserving chronological order.
- Send `startTime` when a cutoff is known to reduce unnecessary historical pagination.
- Add focused local regression tests for pagination, per-app update filtering, partial-page failure behavior, global output ordering, and `startTime` requests.

## Why
The collector previously read only the first `activities.list` response and reused a mutated `from_date` across apps in update mode. Both behaviors can silently omit incident-response audit records.

## Validation
- `python3 -m unittest discover -v`
- `python3 -m py_compile GWS/gws-log-collection/gws-get-logs.py test_gws_get_logs.py`
- `git diff --check`
